### PR TITLE
Replaced dls-controls with DiamondLightSource

### DIFF
--- a/.gitremotes
+++ b/.gitremotes
@@ -1,4 +1,4 @@
-dls-controls git@github.com:dls-controls/ADEiger.git
+DiamondLightSource git@github.com:DiamondLightSource/ADEiger.git
 gitolite ssh://dascgitolite@dasc-git.diamond.ac.uk/controls/support/ADEiger
 upstream git@github.com:brunoseivam/ADEiger.git
 


### PR DESCRIPTION
Repository was automatically transferred from `dls-controls/ADEiger` using https://gitlab.diamond.ac.uk/github/github-scripts